### PR TITLE
Idea: Allow salt to be a JSON object.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,7 +70,12 @@ function addPackageData (inputs, path) {
 function computeHash (pepper, salt, paths) {
   const inputs = []
   if (pepper) inputs.push(pepper)
-  if (salt) inputs.push(salt)
+  if (salt) {
+    if (typeof salt === 'object' && !Buffer.isBuffer(salt)) {
+      salt = JSON.stringify(salt)
+    }
+    inputs.push(salt)
+  }
 
   for (let i = 0; i < paths.length; i++) {
     addPackageData(inputs, paths[i])

--- a/test/sync.js
+++ b/test/sync.js
@@ -56,8 +56,39 @@ test('can be called with a file', t => {
   t.true(actual === expected)
 })
 
-test('an additional salt can be provided', t => {
+test('salt can be a Buffer', t => {
   const salt = randomBytes(16)
+  const dir = resolve('fixtures', 'unpacked', 'just-a-package')
+  const file = join(dir, 'package.json')
+  const actual = sync(file, salt)
+  const expected = md5hex([
+    ownHash,
+    salt,
+    dir,
+    bytes(files['just-a-package']['package.json'])
+  ])
+
+  t.true(actual === expected)
+})
+
+test('salt can be a JSON object', t => {
+  const salt = {foo: 'bar'}
+  const stringifiedSalt = JSON.stringify(salt)
+  const dir = resolve('fixtures', 'unpacked', 'just-a-package')
+  const file = join(dir, 'package.json')
+  const actual = sync(file, salt)
+  const expected = md5hex([
+    ownHash,
+    stringifiedSalt,
+    dir,
+    bytes(files['just-a-package']['package.json'])
+  ])
+
+  t.true(actual === expected)
+})
+
+test('salt can be a String', t => {
+  const salt = 'foobar'
   const dir = resolve('fixtures', 'unpacked', 'just-a-package')
   const file = join(dir, 'package.json')
   const actual = sync(file, salt)


### PR DESCRIPTION
Not sure this is a good one. It does add convenience, but there is some ambiguity to JSON.stringify (order of property names, etc). That seems unlikely to cause false cache hits, but it certainly could cause cache misses.
