### PR TITLE
Return rejected promise from async method on failure.

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,11 @@ function run (zalgo, paths, salt) {
 }
 
 module.exports = (paths, salt) => {
-  return run(releaseZalgo.async(), paths, salt)
+  try {
+    return run(releaseZalgo.async(), paths, salt)
+  } catch (err) {
+    return Promise.reject(err)
+  }
 }
 module.exports.sync = (paths, salt) => {
   const result = run(releaseZalgo.sync(), paths, salt)

--- a/test/async.js
+++ b/test/async.js
@@ -63,7 +63,7 @@ test('can be called with a file', async t => {
   ['a function', () => {}]
 ].forEach(([label, salt]) => {
   test(`salt cannot be ${label}`, async t => {
-    const err = await t.throws(() => async(projectDir, salt), TypeError)
+    const err = await t.throws(async(projectDir, salt), TypeError)
     t.is(err.message, 'Salt must be an Array, Buffer, Object or string')
   })
 })


### PR DESCRIPTION
Specifically this captures `TypeError('Salt must be an Array, Buffer, Object or string')` from `computeHash`, converts it to a rejected promise.  I tried changing `computeHash` to just return a rejected promise but this caused the sync tests to fail.