### PR TITLE
Switch hash function from MD5 to SHA256.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const path = require('path')
 
 const gfs = require('graceful-fs')
 const flattenDeep = require('lodash.flattendeep')
-const md5hex = require('md5-hex')
+const hasha = require('hasha')
 const releaseZalgo = require('release-zalgo')
 
 const PACKAGE_FILE = require.resolve('./package.json')
@@ -126,7 +126,7 @@ function computeHash (zalgo, paths, pepper, salt) {
   }
 
   return zalgo.all(paths.map(pkgPath => addPackageData(zalgo, pkgPath)))
-    .then(furtherInputs => md5hex(flattenDeep([inputs, furtherInputs])))
+    .then(furtherInputs => hasha(flattenDeep([inputs, furtherInputs]), {algorithm: 'sha256'}))
 }
 
 let ownHash = null

--- a/package-lock.json
+++ b/package-lock.json
@@ -3369,6 +3369,14 @@
         }
       }
     },
+    "hasha": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-3.0.0.tgz",
+      "integrity": "sha1-UqMvq4Vp1BymmmH/GiFPjrfIvTk=",
+      "requires": {
+        "is-stream": "^1.0.1"
+      }
+    },
     "hosted-git-info": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
@@ -3823,8 +3831,7 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-      "dev": true
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -4255,6 +4262,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-2.0.0.tgz",
       "integrity": "sha1-0FiOnxx0lUSS7NJKwKxs6ZfZLjM=",
+      "dev": true,
       "requires": {
         "md5-o-matic": "^0.1.1"
       }
@@ -4262,7 +4270,8 @@
     "md5-o-matic": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
-      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
+      "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
+      "dev": true
     },
     "meow": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "homepage": "https://github.com/novemberborn/package-hash#readme",
   "dependencies": {
     "graceful-fs": "^4.1.15",
+    "hasha": "^3.0.0",
     "lodash.flattendeep": "^4.4.0",
-    "md5-hex": "^2.0.0",
     "release-zalgo": "^1.0.0"
   },
   "devDependencies": {

--- a/test/async.js
+++ b/test/async.js
@@ -4,7 +4,7 @@ import {randomBytes} from 'crypto'
 import {join, resolve as resolvePath} from 'path'
 
 import test from 'ava'
-import md5hex from 'md5-hex'
+import hasha from 'hasha'
 
 import packageHash from '..'
 import {files, diffs} from './fixtures/index.json'
@@ -49,11 +49,11 @@ test('can be called with a file', async t => {
   const dir = resolveFixture('unpacked', 'just-a-package')
   const file = join(dir, 'package.json')
   const actual = await async(file)
-  const expected = md5hex([
+  const expected = hasha([
     ownHash,
     dir,
     bytes(files['just-a-package']['package.json'])
-  ])
+  ], {algorithm: 'sha256'})
 
   t.true(actual === expected)
 })
@@ -81,12 +81,12 @@ test('can be called with a file', async t => {
     const dir = resolveFixture('unpacked', 'just-a-package')
     const file = join(dir, 'package.json')
     const actual = await async(file, salt)
-    const expected = md5hex([
+    const expected = hasha([
       ownHash,
       stringifiedSalt,
       dir,
       bytes(files['just-a-package']['package.json'])
-    ])
+    ], {algorithm: 'sha256'})
 
     t.true(actual === expected)
   })
@@ -100,7 +100,7 @@ test('can be called with a list of files', async t => {
   const file2 = join(dir2, 'package.json')
 
   const actual = await async([file, file2], salt)
-  const expected = md5hex([
+  const expected = hasha([
     ownHash,
     salt,
     dir,
@@ -108,7 +108,7 @@ test('can be called with a list of files', async t => {
     bytes(files['head-is-a-commit']['.git/HEAD']),
     dir2,
     bytes(files['just-a-package']['package.json'])
-  ])
+  ], {algorithm: 'sha256'})
 
   t.true(actual === expected)
 })
@@ -124,7 +124,7 @@ test('can be called with a list of files', async t => {
   test(`${fixture} is hashed correctly`, async t => {
     const dir = resolveFixture('unpacked', fixture)
     const actual = await async(join(dir, 'package.json'))
-    const expected = md5hex([
+    const expected = hasha([
       ownHash,
       dir,
       bytes(files[fixture]['package.json']),
@@ -132,7 +132,7 @@ test('can be called with a list of files', async t => {
       bytes(files[fixture]['.git/packed-refs']),
       bytes(files[fixture]['.git/refs/heads/master']),
       bytes(diffs[fixture])
-    ].filter(Boolean))
+    ].filter(Boolean), {algorithm: 'sha256'})
 
     t.true(actual === expected)
   })

--- a/test/sync.js
+++ b/test/sync.js
@@ -3,7 +3,7 @@ import {randomBytes} from 'crypto'
 import {join, resolve as resolvePath} from 'path'
 
 import test from 'ava'
-import md5hex from 'md5-hex'
+import hasha from 'hasha'
 
 import {sync} from '..'
 import {files, diffs} from './fixtures/index.json'
@@ -42,11 +42,11 @@ test('can be called with a file', t => {
   const dir = resolveFixture('unpacked', 'just-a-package')
   const file = join(dir, 'package.json')
   const actual = sync(file)
-  const expected = md5hex([
+  const expected = hasha([
     ownHash,
     dir,
     bytes(files['just-a-package']['package.json'])
-  ])
+  ], {algorithm: 'sha256'})
 
   t.true(actual === expected)
 })
@@ -74,12 +74,12 @@ test('can be called with a file', t => {
     const dir = resolveFixture('unpacked', 'just-a-package')
     const file = join(dir, 'package.json')
     const actual = sync(file, salt)
-    const expected = md5hex([
+    const expected = hasha([
       ownHash,
       stringifiedSalt,
       dir,
       bytes(files['just-a-package']['package.json'])
-    ])
+    ], {algorithm: 'sha256'})
 
     t.true(actual === expected)
   })
@@ -93,7 +93,7 @@ test('can be called with a list of files', t => {
   const file2 = join(dir2, 'package.json')
 
   const actual = sync([file, file2], salt)
-  const expected = md5hex([
+  const expected = hasha([
     ownHash,
     salt,
     dir,
@@ -101,7 +101,7 @@ test('can be called with a list of files', t => {
     bytes(files['head-is-a-commit']['.git/HEAD']),
     dir2,
     bytes(files['just-a-package']['package.json'])
-  ])
+  ], {algorithm: 'sha256'})
 
   t.true(actual === expected)
 })
@@ -117,7 +117,7 @@ test('can be called with a list of files', t => {
   test(`${fixture} is hashed correctly`, t => {
     const dir = resolveFixture('unpacked', fixture)
     const actual = sync(join(dir, 'package.json'))
-    const expected = md5hex([
+    const expected = hasha([
       ownHash,
       dir,
       bytes(files[fixture]['package.json']),
@@ -125,7 +125,7 @@ test('can be called with a list of files', t => {
       bytes(files[fixture]['.git/packed-refs']),
       bytes(files[fixture]['.git/refs/heads/master']),
       bytes(diffs[fixture])
-    ].filter(Boolean))
+    ].filter(Boolean), {algorithm: 'sha256'})
 
     t.true(actual === expected)
   })


### PR DESCRIPTION
This is needed for compatibility with systems that have FIPS enabled.
On those systems any call to md5hex throws an exception.

Ref: https://github.com/istanbuljs/nyc/issues/869

----

@novemberborn This is the last patch I have planned.  Anything else you want to see happen before making a semver-major release?